### PR TITLE
fixed the jSequencr project link in the README.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ Once the library is loaded, you will have access to jSqncr.sounds, a key-value s
     jSqncr.sounds = {
       "kick": "http://www.examplesounds.com/kick.wav",
       "snare": "/sounds/snare.mp3",
-      "clap": "../clappityclap.aac"    
+      "clap": "../clappityclap.aac"
   	};
 
 On page load or when adding sounds to your key-value store, you can then buffer (aka load into memory) your audio files from their sources by calling:
@@ -26,7 +26,7 @@ You should hear your thumping kick drum!
 ## Considerations
 Due to the nature of Javascript you will have to wait until the initialize function has completed retriving and buffering the sounds before you are given the ability to play them, this is quick process but may require the use of a callback if you wish to play a sound immediately once the sound(s) have loaded.
 ## Credit
-Major credit goes to the makers of the HTML5 audio library and the folks below who's colaboration on this [music sequencer](jSequencr.herokuapp.com) helped inspire this project.
+Major credit goes to the makers of the HTML5 audio library and the folks below who's colaboration on this [music sequencer](http://jSequencr.herokuapp.com) helped inspire this project.
 
 * [Grander Abuhoff](http://github.com/cranbury)
 * [Drew Tunney](http://github.com/drewtunney)


### PR DESCRIPTION
It was just missing the http:// so it was assuming it was a relative path inside of GitHub.
